### PR TITLE
Minor fixes in StatsD module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,7 @@ lazy val statsd = (project in file("statsd")).
     javaSettings,
     name := "metrics-statsd",
     libraryDependencies ++= Seq(
-      "com.datadoghq" % "java-dogstatsd-client" % "2.3"
+      "com.datadoghq" % "java-dogstatsd-client" % "2.3",
+      "org.slf4j" % "slf4j-api" % "1.7.22"
     )
   ).dependsOn(core)

--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
@@ -2,12 +2,16 @@ package com.avast.metrics.statsd;
 
 import com.avast.metrics.api.Gauge;
 import com.timgroup.statsd.StatsDClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Supplier;
 
 public class StatsDGauge<T> implements Gauge<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatsDGauge.class);
+
     private final StatsDClient client;
     private final String name;
     private final Supplier<T> supplier;
@@ -47,6 +51,8 @@ public class StatsDGauge<T> implements Gauge<T> {
             sendDoubleValue(((BigDecimal) o).doubleValue());
         } else if (o instanceof Boolean) {
             sendLongValue(((Boolean) o) ? 1 : 0);
+        } else {
+            LOGGER.warn("Unsupported gauge type: {}", o.getClass());
         }
     }
 

--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDMeter.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDMeter.java
@@ -3,7 +3,6 @@ package com.avast.metrics.statsd;
 import com.avast.metrics.api.Meter;
 import com.timgroup.statsd.StatsDClient;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class StatsDMeter implements Meter {
@@ -30,7 +29,7 @@ public class StatsDMeter implements Meter {
 
     @Override
     public void mark(final long n) {
-        marks.incrementAndGet();
+        marks.addAndGet(n);
         client.count(name, n);
     }
 

--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDTimer.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDTimer.java
@@ -42,10 +42,9 @@ public class StatsDTimer implements Timer {
 
     @Override
     public <T> T time(final Callable<T> operation) throws Exception {
-        final TimeContext context = start();
-        final T result = operation.call();
-        context.stop();
-        return result;
+        try (TimeContext ignored = start()) {
+            return operation.call();
+        }
     }
 
     @Override


### PR DESCRIPTION
- Log unsupported gauge type to prevent silent failures.
- Fix StatsDMeter.mark(n)
- Record time in StatsDTimer even in case of exception.