### PR TITLE
Prometheus formatter: remove invalid characters from name.

### DIFF
--- a/formatting/src/main/java/com/avast/metrics/dropwizard/formatting/PrometheusFormatter.java
+++ b/formatting/src/main/java/com/avast/metrics/dropwizard/formatting/PrometheusFormatter.java
@@ -39,9 +39,8 @@ public class PrometheusFormatter implements Formatter {
                     || c >= '0' && c <= '9'
                     || c == ':') {
                 result.append(c);
-            } else {
-                result.append('X'); // Nothing better in the allowed characters
             }
+            // else remove the character, there is no usable replacement in the set of allowed characters
         }
 
         return result.toString();

--- a/formatting/src/test/java/com/avast/metrics/dropwizard/formatting/PrometheusFormatterTest.java
+++ b/formatting/src/test/java/com/avast/metrics/dropwizard/formatting/PrometheusFormatterTest.java
@@ -13,7 +13,7 @@ public class PrometheusFormatterTest {
 
     @Test
     public void testSanitize() throws Exception {
-        assertEquals("XX:XXXXXXabcdefghXXX:XXXXXXabcdefghX",
+        assertEquals(":abcdefgh:abcdefgh",
                 formatter.sanitizeName(". :|@\n=()abcdefgh_. :|@\n=()abcdefgh_"));
     }
 


### PR DESCRIPTION
- Previous version used 'X' as replacement, but it seems messy to users.

(requested by @hanny24)