### PR TITLE
Fix timer duration units.

### DIFF
--- a/dropwizard-common/src/main/java/com/avast/metrics/dropwizard/MetricsTimer.java
+++ b/dropwizard-common/src/main/java/com/avast/metrics/dropwizard/MetricsTimer.java
@@ -25,7 +25,7 @@ public class MetricsTimer implements Timer {
 
     @Override
     public void update(Duration duration) {
-        metricsTimer.update(duration.toMillis(), TimeUnit.MILLISECONDS);
+        metricsTimer.update(duration.toNanos(), TimeUnit.NANOSECONDS);
     }
 
     @Override

--- a/formatting/src/main/java/com/avast/metrics/dropwizard/formatting/FormattingMetricsMonitor.java
+++ b/formatting/src/main/java/com/avast/metrics/dropwizard/formatting/FormattingMetricsMonitor.java
@@ -242,19 +242,19 @@ public class FormattingMetricsMonitor extends MetricsMonitor {
         if (timerFormatting.isFifteenMinuteRate())
             values.add(new MetricValue(appendName(name, "rate15m"), formatter.formatNumber(timer.getFifteenMinuteRate())));
         if (timerFormatting.isMin())
-            values.add(new MetricValue(appendName(name, "min"), formatter.formatNumber(snapshot.getMin())));
+            values.add(new MetricValue(appendName(name, "min"), formatter.formatNumber(ns2ms(snapshot.getMin()))));
         if (timerFormatting.isMax())
-            values.add(new MetricValue(appendName(name, "max"), formatter.formatNumber(snapshot.getMax())));
+            values.add(new MetricValue(appendName(name, "max"), formatter.formatNumber(ns2ms(snapshot.getMax()))));
         if (timerFormatting.isMean())
-            values.add(new MetricValue(appendName(name, "mean"), formatter.formatNumber(snapshot.getMean())));
+            values.add(new MetricValue(appendName(name, "mean"), formatter.formatNumber(ns2ms(snapshot.getMean()))));
         if (timerFormatting.isStdDev())
-            values.add(new MetricValue(appendName(name, "stddev"), formatter.formatNumber(snapshot.getStdDev())));
+            values.add(new MetricValue(appendName(name, "stddev"), formatter.formatNumber(ns2ms(snapshot.getStdDev()))));
 
         timerFormatting
                 .getPercentiles()
                 .forEach(percentile ->
                         values.add(new MetricValue(appendName(name, percentileName(percentile)),
-                                formatter.formatNumber(snapshot.getValue(percentile)))));
+                                formatter.formatNumber(ns2ms(snapshot.getValue(percentile))))));
 
         return values.stream();
     }
@@ -272,5 +272,13 @@ public class FormattingMetricsMonitor extends MetricsMonitor {
 
     private String appendName(String base, String part) {
         return base + formatter.nameSeparator() + part;
+    }
+
+    private long ns2ms(long nanoseconds) {
+        return nanoseconds / 1_000_000L;
+    }
+
+    private double ns2ms(double nanoseconds) {
+        return nanoseconds / 1_000_000.0;
     }
 }

--- a/formatting/src/test/java/com/avast/metrics/dropwizard/formatting/FormattingMetricsMonitorTest.java
+++ b/formatting/src/test/java/com/avast/metrics/dropwizard/formatting/FormattingMetricsMonitorTest.java
@@ -1,6 +1,7 @@
 package com.avast.metrics.dropwizard.formatting;
 
 import com.avast.metrics.api.Counter;
+import com.avast.metrics.api.Timer;
 import com.avast.metrics.dropwizard.formatting.fields.FieldsFormatting;
 import com.avast.metrics.filter.FilterConfig;
 import com.avast.metrics.filter.MetricsFilter;
@@ -9,6 +10,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -287,6 +289,25 @@ public class FormattingMetricsMonitorTest {
                     "env.dc.app.inst.monitor.timer.stddev 0.0";
 
             assertEquals(expected, monitor.format(filter, FormattingMetricsMonitorTest.FIELDS_ALL_ENABLED));
+        }
+    }
+
+    @Test
+    public void testTimerDurationUnit() throws Exception {
+        try (FormattingMetricsMonitor monitor = new FormattingMetricsMonitor(new GraphiteFormatter(), Collections.emptyList())) {
+            Timer timer = monitor.newTimer("timer");
+            timer.update(Duration.ofMillis(42));
+
+            Timer timerNs = monitor.newTimer("timerNs");
+            timerNs.update(Duration.ofNanos(42));
+
+            String expected = "timer.count 1\n" +
+                    "timer.p50 42.0\n" +
+                    "timer.p99 42.0\n" +
+                    "timerNs.count 1\n" +
+                    "timerNs.p50 4.2E-5\n" +
+                    "timerNs.p99 4.2E-5";
+            assertEquals(expected, monitor.format(MetricsFilter.ALL_ENABLED, FieldsFormatting.defaults()));
         }
     }
 }

--- a/graphite/src/main/java/com/avast/metrics/dropwizard/GraphiteMetricsMonitor.java
+++ b/graphite/src/main/java/com/avast/metrics/dropwizard/GraphiteMetricsMonitor.java
@@ -1,7 +1,6 @@
 package com.avast.metrics.dropwizard;
 
 import com.avast.metrics.api.Naming;
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;


### PR DESCRIPTION
- Dropwizard internally works with nanosecond precision for durations and seconds for rates, but reporters (e.g. JMX one) use milliseconds for durations by default.
- Fix precision loss in MetricsTimer.update(Duration) (ns->ms->ns).
- Update FormattingMetricsMonitor to be compatible with the rest of the library and use milliseconds for durations too.