### PR TITLE
sampleRate not set for gauges in StatsD (if not required)

### DIFF
--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
@@ -15,17 +15,11 @@ public class StatsDGauge<T> implements Gauge<T>, StatsDMetric {
     private final StatsDClient client;
     private final String name;
     private final Supplier<T> supplier;
-    private double sampleRate;
 
     StatsDGauge(final StatsDClient client, final String name, final Supplier<T> supplier) {
-        this(client, name, supplier, 1.0);
-    }
-
-    StatsDGauge(final StatsDClient client, final String name, final Supplier<T> supplier, double sampleRate) {
         this.client = client;
         this.name = name;
         this.supplier = supplier;
-        this.sampleRate = sampleRate;
     }
 
     @Override
@@ -63,11 +57,11 @@ public class StatsDGauge<T> implements Gauge<T>, StatsDMetric {
     }
 
     private void sendLongValue(long l) {
-        if (sampleRate == 1.0) client.recordGaugeValue(name, l); else client.recordGaugeValue(name, l, sampleRate);
+        client.recordGaugeValue(name, l);
     }
 
     private void sendDoubleValue(double d) {
-        if (sampleRate == 1.0) client.recordGaugeValue(name, d); else client.recordGaugeValue(name, d, sampleRate);
+        client.recordGaugeValue(name, d);
     }
 
     @Override

--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDGauge.java
@@ -63,11 +63,11 @@ public class StatsDGauge<T> implements Gauge<T>, StatsDMetric {
     }
 
     private void sendLongValue(long l) {
-        client.recordGaugeValue(name, l, sampleRate);
+        if (sampleRate == 1.0) client.recordGaugeValue(name, l); else client.recordGaugeValue(name, l, sampleRate);
     }
 
     private void sendDoubleValue(double d) {
-        client.recordGaugeValue(name, d, sampleRate);
+        if (sampleRate == 1.0) client.recordGaugeValue(name, d); else client.recordGaugeValue(name, d, sampleRate);
     }
 
     @Override

--- a/statsd/src/main/java/com/avast/metrics/statsd/StatsDMetricsMonitor.java
+++ b/statsd/src/main/java/com/avast/metrics/statsd/StatsDMetricsMonitor.java
@@ -188,7 +188,7 @@ public class StatsDMetricsMonitor implements Monitor {
                     existing.cancel(false);
                 }
 
-                final StatsDGauge<T> gauge = init(new StatsDGauge<>(client, metricName, supplier, config.getSampleRate()));
+                final StatsDGauge<T> gauge = init(new StatsDGauge<>(client, metricName, supplier));
 
                 final ScheduledFuture<?> scheduled = scheduler.scheduleAtFixedRate(gauge::send, 0, gaugeSendPeriod.toMillis(), TimeUnit.MILLISECONDS);
 

--- a/statsd/src/test/java/com/avast/metrics/statsd/StatsDGaugeTest.java
+++ b/statsd/src/test/java/com/avast/metrics/statsd/StatsDGaugeTest.java
@@ -21,7 +21,7 @@ public class StatsDGaugeTest {
             dGauge.send();
         }
 
-        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI), Matchers.anyDouble());
+        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI));
 
         assertEquals(Math.PI, dGauge.getValue(), 0);
     }
@@ -38,7 +38,7 @@ public class StatsDGaugeTest {
             dGauge.send();
         }
 
-        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Long.MAX_VALUE), Matchers.anyDouble());
+        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Long.MAX_VALUE));
 
         assertEquals(Long.MAX_VALUE, dGauge.getValue(), 0);
     }
@@ -55,7 +55,7 @@ public class StatsDGaugeTest {
             dGauge.send();
         }
 
-        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq((long) Integer.MAX_VALUE), Matchers.anyDouble());
+        verify(client, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq((long) Integer.MAX_VALUE));
 
         assertEquals(Integer.MAX_VALUE, dGauge.getValue(), 0);
     }

--- a/statsd/src/test/java/com/avast/metrics/statsd/StatsDMetricsMonitorTest.java
+++ b/statsd/src/test/java/com/avast/metrics/statsd/StatsDMetricsMonitorTest.java
@@ -48,7 +48,7 @@ public class StatsDMetricsMonitorTest {
 
             verify(scheduler, times(1)).scheduleAtFixedRate(Matchers.any(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any());
 
-            verify(statsDClient, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI), Matchers.anyDouble());
+            verify(statsDClient, times(5)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI));
         }
     }
 
@@ -79,13 +79,13 @@ public class StatsDMetricsMonitorTest {
             assertNotNull(monitor.newGauge(name, () -> Math.PI));
 
             verify(scheduler, times(1)).scheduleAtFixedRate(Matchers.any(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any());
-            verify(statsDClient, times(1)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI), Matchers.anyDouble());
+            verify(statsDClient, times(1)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI));
 
 
             // request the same again, the old one should be cancelled
             assertNotNull(monitor.newGauge(name, true, () -> Math.PI));
 
-            verify(statsDClient, times(2)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI), Matchers.anyDouble());
+            verify(statsDClient, times(2)).recordGaugeValue(Matchers.eq(name), Matchers.eq(Math.PI));
             verify(scheduler, times(2)).scheduleAtFixedRate(Matchers.any(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any());
             verify(scheduledFuture, times(1)).cancel(Matchers.anyBoolean());
         }


### PR DESCRIPTION
StatsD works with current code because it ignores sample rates sent with gauges. But current version of statsite (more performant implementation of the StatsD protocol) drops gauges with sample rate.

So this is why I propose this change - don't send sample rate on the wire-level if sample rate is set to `1.0`.