### PR TITLE
grpc: Differentiate between client and server failures

### DIFF
--- a/grpc/src/main/java/com/avast/metrics/grpc/ErrorCategory.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/ErrorCategory.java
@@ -6,8 +6,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class MetricCategory {
-    static Set<Status.Code> clientErrors = new HashSet<>(Arrays.asList(
+public class ErrorCategory {
+    static Set<Status.Code> client = new HashSet<>(Arrays.asList(
             Status.Code.INVALID_ARGUMENT,
             Status.Code.UNAUTHENTICATED,
             Status.Code.PERMISSION_DENIED

--- a/grpc/src/main/java/com/avast/metrics/grpc/ErrorCategory.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/ErrorCategory.java
@@ -12,4 +12,8 @@ public class ErrorCategory {
             Status.Code.UNAUTHENTICATED,
             Status.Code.PERMISSION_DENIED
     ));
+    static Set<Status.Code> fatal = new HashSet<>(Arrays.asList(
+            Status.Code.INTERNAL,
+            Status.Code.UNKNOWN
+    ));
 }

--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
@@ -41,6 +41,9 @@ public class GrpcServerMonitoringInterceptor implements ServerInterceptor {
                 } else if(ErrorCategory.client.contains(status.getCode())) {
                     cache.getTimer(metricPrefix + "ClientFailures")
                             .update(duration);
+                } else if(ErrorCategory.fatal.contains(status.getCode())) {
+                    cache.getTimer(metricPrefix + "FatalServerFailures")
+                            .update(duration);
                 } else {
                     cache.getTimer(metricPrefix + "ServerFailures")
                             .update(duration);

--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
@@ -38,7 +38,7 @@ public class GrpcServerMonitoringInterceptor implements ServerInterceptor {
                 if (status.isOk()) {
                     cache.getTimer(metricPrefix + "Successes")
                             .update(duration);
-                } else if(MetricCategory.clientErrors.contains(status.getCode())) {
+                } else if(ErrorCategory.client.contains(status.getCode())) {
                     cache.getTimer(metricPrefix + "ClientFailures")
                             .update(duration);
                 } else {

--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
@@ -38,8 +38,11 @@ public class GrpcServerMonitoringInterceptor implements ServerInterceptor {
                 if (status.isOk()) {
                     cache.getTimer(metricPrefix + "Successes")
                             .update(duration);
+                } else if(MetricCategory.clientErrors.contains(status.getCode())) {
+                    cache.getTimer(metricPrefix + "ClientFailures")
+                            .update(duration);
                 } else {
-                    cache.getTimer(metricPrefix + "Failures")
+                    cache.getTimer(metricPrefix + "ServerFailures")
                             .update(duration);
                 }
 

--- a/grpc/src/main/java/com/avast/metrics/grpc/MetricCategory.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/MetricCategory.java
@@ -1,0 +1,15 @@
+package com.avast.metrics.grpc;
+
+import io.grpc.Status;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MetricCategory {
+    static Set<Status.Code> clientErrors = new HashSet<>(Arrays.asList(
+            Status.Code.INVALID_ARGUMENT,
+            Status.Code.UNAUTHENTICATED,
+            Status.Code.PERMISSION_DENIED
+    ));
+}

--- a/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
+++ b/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
@@ -78,7 +78,7 @@ public class GrpcServerMonitoringInterceptorTest {
 
         final Monitor monitor = mock(Monitor.class);
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_GetFailures")).thenReturn(timer);
+        when(monitor.newTimer("TestApiService_GetFatalServerFailures")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.10


### PR DESCRIPTION
`*FatalServerFailures` (INERNAL, UNKNOWN) are subsumed under `*ServerFailures`, just as with logging, they are reported as ERROR while the others are WARN