### PR TITLE
grpc: put underscore before "Failures" in names for easier matching

### DIFF
--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
@@ -39,13 +39,13 @@ public class GrpcServerMonitoringInterceptor implements ServerInterceptor {
                     cache.getTimer(metricPrefix + "Successes")
                             .update(duration);
                 } else if(ErrorCategory.client.contains(status.getCode())) {
-                    cache.getTimer(metricPrefix + "ClientFailures")
+                    cache.getTimer(metricPrefix + "_ClientFailures")
                             .update(duration);
                 } else if(ErrorCategory.fatal.contains(status.getCode())) {
-                    cache.getTimer(metricPrefix + "FatalServerFailures")
+                    cache.getTimer(metricPrefix + "_FatalServerFailures")
                             .update(duration);
                 } else {
-                    cache.getTimer(metricPrefix + "ServerFailures")
+                    cache.getTimer(metricPrefix + "_ServerFailures")
                             .update(duration);
                 }
 

--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptor.java
@@ -36,16 +36,16 @@ public class GrpcServerMonitoringInterceptor implements ServerInterceptor {
                 currentCalls.decrementAndGet();
 
                 if (ErrorCategory.fatal.contains(status.getCode())) {
-                    cache.getTimer(metricPrefix + "_FatalServerFailures")
+                    cache.getTimer(metricPrefix + "FatalServerFailures")
                             .update(duration);
-                } else if(ErrorCategory.client.contains(status.getCode())) {
-                    cache.getTimer(metricPrefix + "_ClientFailures")
+                } else if (ErrorCategory.client.contains(status.getCode())) {
+                    cache.getTimer(metricPrefix + "ClientFailures")
                             .update(duration);
                 } else if (status.isOk()) {
-                    cache.getTimer(metricPrefix + "_Successes")
+                    cache.getTimer(metricPrefix + "Successes")
                             .update(duration);
                 } else {
-                    cache.getTimer(metricPrefix + "_ServerFailures")
+                    cache.getTimer(metricPrefix + "ServerFailures")
                             .update(duration);
                 }
 

--- a/grpc/src/main/java/com/avast/metrics/grpc/MetricNaming.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/MetricNaming.java
@@ -7,6 +7,6 @@ class MetricNaming {
     private MetricNaming() {}
 
     static <ReqT, RespT>String getMetricNamePrefix(MethodDescriptor<ReqT, RespT> methodDescriptor) {
-        return methodDescriptor.getFullMethodName().replace('/', '_');
+        return methodDescriptor.getFullMethodName().replace('/', '_') + "_";
     }
 }

--- a/grpc/src/test/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptorTest.java
+++ b/grpc/src/test/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptorTest.java
@@ -31,11 +31,11 @@ public class GrpcClientMonitoringInterceptorTest {
 
         final Monitor monitor = mock(Monitor.class);
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_GetSuccesses")).thenReturn(timer);
+        when(monitor.newTimer("TestApiService_Get_Successes")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_GetCurrent"), any())).thenAnswer(invocation -> {
+        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });
@@ -81,11 +81,11 @@ public class GrpcClientMonitoringInterceptorTest {
 
         final Monitor monitor = mock(Monitor.class);
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_GetFailures")).thenReturn(timer);
+        when(monitor.newTimer("TestApiService_Get_FatalServerFailures")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_GetCurrent"), any())).thenAnswer(invocation -> {
+        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });

--- a/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
+++ b/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
@@ -32,11 +32,11 @@ public class GrpcServerMonitoringInterceptorTest {
 
         final Monitor monitor = mock(Monitor.class);
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_GetSuccesses")).thenReturn(timer);
+        when(monitor.newTimer("TestApiService_Get_Successes")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_GetCurrent"), any())).thenAnswer(invocation -> {
+        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });
@@ -78,11 +78,11 @@ public class GrpcServerMonitoringInterceptorTest {
 
         final Monitor monitor = mock(Monitor.class);
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_GetFatalServerFailures")).thenReturn(timer);
+        when(monitor.newTimer("TestApiService_Get_FatalServerFailures")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_GetCurrent"), any())).thenAnswer(invocation -> {
+        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });


### PR DESCRIPTION
Question also is, whether we shouldn't perhaps put underscore to `_Successes` too
