### PR TITLE
gRPC metrics names fixed

### DIFF
--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptor.java
@@ -23,8 +23,7 @@ public class GrpcClientMonitoringInterceptor implements ClientInterceptor {
 
     @Override
     public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(final MethodDescriptor<ReqT, RespT> method, final CallOptions callOptions, final Channel next) {
-        final String metricPrefix = MetricNaming.getMetricNamePrefix(method);
-        final AtomicInteger currentCalls = cache.getGaugedValue(metricPrefix + "Current");
+        final AtomicInteger currentCalls = cache.getGaugedValue(method, "Current");
 
         final Instant start = clock.instant();
         currentCalls.incrementAndGet();
@@ -41,16 +40,16 @@ public class GrpcClientMonitoringInterceptor implements ClientInterceptor {
                                 currentCalls.decrementAndGet();
 
                                 if (ErrorCategory.fatal.contains(status.getCode())) {
-                                    cache.getTimer(metricPrefix + "FatalServerFailures")
+                                    cache.getTimer(method, "FatalServerFailures")
                                             .update(duration);
                                 } else if (ErrorCategory.client.contains(status.getCode())) {
-                                    cache.getTimer(metricPrefix + "ClientFailures")
+                                    cache.getTimer(method, "ClientFailures")
                                             .update(duration);
                                 } else if (status.isOk()) {
-                                    cache.getTimer(metricPrefix + "Successes")
+                                    cache.getTimer(method, "Successes")
                                             .update(duration);
                                 } else {
-                                    cache.getTimer(metricPrefix + "ServerFailures")
+                                    cache.getTimer(method, "ServerFailures")
                                             .update(duration);
                                 }
 

--- a/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerUsernameMonitoringInterceptor.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/GrpcServerUsernameMonitoringInterceptor.java
@@ -1,0 +1,30 @@
+package com.avast.metrics.grpc;
+
+import com.avast.metrics.api.Monitor;
+import io.grpc.*;
+
+import java.util.function.Supplier;
+
+public class GrpcServerUsernameMonitoringInterceptor implements ServerInterceptor {
+    private final MetricsCache cache;
+    private final Supplier<String> usernameSupplier;
+
+    /*
+     * @param usernameSupplier Callback that is called from the right gRPC Context so can access its values.
+     */
+    public GrpcServerUsernameMonitoringInterceptor(final Monitor monitor, Supplier<String> usernameSupplier) {
+        cache = new MetricsCache(monitor);
+        this.usernameSupplier = usernameSupplier;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        return new ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(next.startCall(call, headers)) {
+            @Override
+            public void onComplete() {
+                cache.getMeter(call.getMethodDescriptor(), usernameSupplier.get()).mark();
+                super.onComplete();
+            }
+        };
+    }
+}

--- a/grpc/src/main/java/com/avast/metrics/grpc/MetricNaming.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/MetricNaming.java
@@ -3,10 +3,10 @@ package com.avast.metrics.grpc;
 
 import io.grpc.MethodDescriptor;
 
-class MetricNaming {
+public class MetricNaming {
     private MetricNaming() {}
 
-    static <ReqT, RespT>String getMetricNamePrefix(MethodDescriptor<ReqT, RespT> methodDescriptor) {
-        return methodDescriptor.getFullMethodName().replace('/', '_') + "_";
+    public static <ReqT, RespT>String getMethodMonitorName(MethodDescriptor<ReqT, RespT> methodDescriptor) {
+        return methodDescriptor.getFullMethodName().replace('/', '_');
     }
 }

--- a/grpc/src/main/java/com/avast/metrics/grpc/MetricsCache.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/MetricsCache.java
@@ -1,27 +1,43 @@
 package com.avast.metrics.grpc;
 
+import com.avast.metrics.api.Meter;
 import com.avast.metrics.api.Monitor;
 import com.avast.metrics.api.Timer;
+import io.grpc.MethodDescriptor;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class MetricsCache {
     private final Monitor monitor;
+    private final ConcurrentHashMap<String, Monitor> methodMonitors = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Timer> timers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Meter> meters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, AtomicInteger> gaugedValues = new ConcurrentHashMap<>();
 
     public MetricsCache(final Monitor monitor) {
         this.monitor = monitor;
     }
 
-    public Timer getTimer(String name) {
-        return timers.computeIfAbsent(name, monitor::newTimer);
+    public <ReqT, RespT> Timer getTimer(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
+        String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
+        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
+        return timers.computeIfAbsent(methodMonitorName + name, (s) -> methodMonitor.newTimer(name));
     }
 
-    public AtomicInteger getGaugedValue(String name) { return gaugedValues.computeIfAbsent(name, n -> {
-        AtomicInteger v = new AtomicInteger();
-        monitor.newGauge(n, v::get);
-        return v;
-    }); }
+    public <ReqT, RespT> Meter getMeter(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
+        String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
+        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
+        return meters.computeIfAbsent(methodMonitorName + name, (s) -> methodMonitor.newMeter(name));
+    }
+
+    public <ReqT, RespT> AtomicInteger getGaugedValue(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
+        String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
+        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
+        return gaugedValues.computeIfAbsent(methodMonitorName + name, n -> {
+            AtomicInteger v = new AtomicInteger();
+            methodMonitor.newGauge(name, v::get);
+            return v;
+        });
+    }
 }

--- a/grpc/src/main/java/com/avast/metrics/grpc/MetricsCache.java
+++ b/grpc/src/main/java/com/avast/metrics/grpc/MetricsCache.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class MetricsCache {
     private final Monitor monitor;
-    private final ConcurrentHashMap<String, Monitor> methodMonitors = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Timer> timers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Meter> meters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, AtomicInteger> gaugedValues = new ConcurrentHashMap<>();
@@ -21,22 +20,19 @@ class MetricsCache {
 
     public <ReqT, RespT> Timer getTimer(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
         String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
-        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
-        return timers.computeIfAbsent(methodMonitorName + name, (s) -> methodMonitor.newTimer(name));
+        return timers.computeIfAbsent(methodMonitorName + name, (s) -> monitor.named(methodMonitorName).newTimer(name));
     }
 
     public <ReqT, RespT> Meter getMeter(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
         String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
-        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
-        return meters.computeIfAbsent(methodMonitorName + name, (s) -> methodMonitor.newMeter(name));
+        return meters.computeIfAbsent(methodMonitorName + name, (s) -> monitor.named(methodMonitorName).newMeter(name));
     }
 
     public <ReqT, RespT> AtomicInteger getGaugedValue(MethodDescriptor<ReqT, RespT> methodDescriptor, String name) {
         String methodMonitorName = MetricNaming.getMethodMonitorName(methodDescriptor);
-        Monitor methodMonitor = methodMonitors.computeIfAbsent(methodMonitorName, monitor::named);
         return gaugedValues.computeIfAbsent(methodMonitorName + name, n -> {
             AtomicInteger v = new AtomicInteger();
-            methodMonitor.newGauge(name, v::get);
+            monitor.named(methodMonitorName).newGauge(name, v::get);
             return v;
         });
     }

--- a/grpc/src/test/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptorTest.java
+++ b/grpc/src/test/java/com/avast/metrics/grpc/GrpcClientMonitoringInterceptorTest.java
@@ -30,12 +30,15 @@ public class GrpcClientMonitoringInterceptorTest {
         final String channelName = UUID.randomUUID().toString();
 
         final Monitor monitor = mock(Monitor.class);
+        final Monitor methodMonitor = mock(Monitor.class);
+        when(monitor.named("TestApiService_Get")).thenReturn(methodMonitor);
+
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_Get_Successes")).thenReturn(timer);
+        when(methodMonitor.newTimer("Successes")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
+        when(methodMonitor.newGauge(eq("Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });
@@ -80,12 +83,15 @@ public class GrpcClientMonitoringInterceptorTest {
         final String channelName = UUID.randomUUID().toString();
 
         final Monitor monitor = mock(Monitor.class);
+        final Monitor methodMonitor = mock(Monitor.class);
+        when(monitor.named("TestApiService_Get")).thenReturn(methodMonitor);
+
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_Get_FatalServerFailures")).thenReturn(timer);
+        when(methodMonitor.newTimer("FatalServerFailures")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
+        when(methodMonitor.newGauge(eq("Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });

--- a/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
+++ b/grpc/src/test/java/com/avast/metrics/grpc/GrpcServerMonitoringInterceptorTest.java
@@ -31,12 +31,15 @@ public class GrpcServerMonitoringInterceptorTest {
         final String channelName = UUID.randomUUID().toString();
 
         final Monitor monitor = mock(Monitor.class);
+        final Monitor methodMonitor = mock(Monitor.class);
+        when(monitor.named("TestApiService_Get")).thenReturn(methodMonitor);
+
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_Get_Successes")).thenReturn(timer);
+        when(methodMonitor.newTimer("Successes")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
+        when(methodMonitor.newGauge(eq("Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });
@@ -77,12 +80,15 @@ public class GrpcServerMonitoringInterceptorTest {
         final String channelName = UUID.randomUUID().toString();
 
         final Monitor monitor = mock(Monitor.class);
+        final Monitor methodMonitor = mock(Monitor.class);
+        when(monitor.named("TestApiService_Get")).thenReturn(methodMonitor);
+
         final Timer timer = mock(Timer.class);
-        when(monitor.newTimer("TestApiService_Get_FatalServerFailures")).thenReturn(timer);
+        when(methodMonitor.newTimer("FatalServerFailures")).thenReturn(timer);
         doNothing().when(timer).update(Matchers.eq(Duration.ofMillis(42)));
 
         AtomicReference<Supplier<Integer>> currentCallsSupplier = new AtomicReference<>();
-        when(monitor.newGauge(eq("TestApiService_Get_Current"), any())).thenAnswer(invocation -> {
+        when(methodMonitor.newGauge(eq("Current"), any())).thenAnswer(invocation -> {
             currentCallsSupplier.set(invocation.getArgumentAt(1, Supplier.class));
             return null;
         });


### PR DESCRIPTION
The main change is that we no longer use `_` as metrics separator, we use `Monitor.named` method instead to create a _child_ `Monitor`.