### PR TITLE
Scala Effect API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Main advantages of this library:
 1) Universal abstraction with misc. implementations
 2) Support of multiple exports at once (`MultiMonitor`)
 3) Scala API
-4) Cats-Effect API
+4) Scala Effect API (cats-effect 2)
 
 The entry-point into the library is the interface `Monitor`. Your classes need to get an instance of a monitor which they can use to construct different metrics, e.g. meters, timers or histograms.
 Instances of the individuals metrics can be used to monitor your application.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Library for application monitoring. It's abstraction of metrics inspired by [Dro
 
 Main advantages of this library:
 1) Universal abstraction with misc. implementations
-1) Support of multiple exports at once (`MultiMonitor`)
-1) Scala API
+2) Support of multiple exports at once (`MultiMonitor`)
+3) Scala API
+4) Cats-Effect API
 
 The entry-point into the library is the interface `Monitor`. Your classes need to get an instance of a monitor which they can use to construct different metrics, e.g. meters, timers or histograms.
 Instances of the individuals metrics can be used to monitor your application.
@@ -91,11 +92,24 @@ a.inc()
 
 ```
 
-See [example in tests](scala-api/src/test/scala/com/avast/metrics/examples/PerKeyExample.scala).
+## Scala Effect API
+
+An easy-to-use Scala Effect API is available in `scala-effect-api` module. Wrap the Java `Monitor` by `scalaeffectapi.Monitor` to use the Cats-Effect version.
+
+```scala
+import com.avast.metrics.scalaeffectapi.Monitor
+import com.avast.metrics.dropwizard.JmxMetricsMonitor
+
+val javaMonitor = getJavaMonitor()
+val scalaEffectMonitor: F[Monitor[F]]  = Monitor(javaMonitor)
+val scalaEffectMonitorUnsafe: Monitor[F]  = Monitor.applyUnsafe(javaMonitor)
+```
+
+See [example in tests](scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala).
 
 ## Unit Testing
 There is a singleton [NoOpMonitor.INSTANCE](api/src/main/java/com/avast/metrics/test/NoOpMonitor.java) in the `metrics-api` submodule that can be used in tests.  
-There is also available `Monitor.noOp` for Scala API.
+There are also available `Monitor.noOp` for Scala API and `Monitor.noOp`/`Monitor.noOpUnsafe` for Scala Effect API.
 
 ## Disabling JMX
 Sometimes you want to globally disable JMX monitoring on the server. You can do that by setting system property `avastMetricsDisableJmx=true`. To do that from bash, you can use:

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ import com.avast.metrics.scalaeffectapi.Monitor
 import com.avast.metrics.dropwizard.JmxMetricsMonitor
 
 val javaMonitor = getJavaMonitor()
-val scalaEffectMonitor: F[Monitor[F]]  = Monitor(javaMonitor)
-val scalaEffectMonitorUnsafe: Monitor[F]  = Monitor.applyUnsafe(javaMonitor)
+val scalaEffectMonitor: F[Monitor[F]]  = Monitor.wrapJava(javaMonitor)
+val scalaEffectMonitorUnsafe: Monitor[F]  = Monitor.wrapJavaUnsafe(javaMonitor)
 ```
 
 See [example in tests](scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala).

--- a/README.md
+++ b/README.md
@@ -101,15 +101,14 @@ import com.avast.metrics.scalaeffectapi.Monitor
 import com.avast.metrics.dropwizard.JmxMetricsMonitor
 
 val javaMonitor = getJavaMonitor()
-val scalaEffectMonitor: F[Monitor[F]]  = Monitor.wrapJava(javaMonitor)
-val scalaEffectMonitorUnsafe: Monitor[F]  = Monitor.wrapJavaUnsafe(javaMonitor)
+val scalaEffectMonitor: Monitor[F]  = Monitor.wrapJava(javaMonitor)
 ```
 
 See [example in tests](scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala).
 
 ## Unit Testing
 There is a singleton [NoOpMonitor.INSTANCE](api/src/main/java/com/avast/metrics/test/NoOpMonitor.java) in the `metrics-api` submodule that can be used in tests.  
-There are also available `Monitor.noOp` for Scala API and `Monitor.noOp`/`Monitor.noOpUnsafe` for Scala Effect API.
+There are also available `Monitor.noOp` for Scala API and Scala Effect API.
 
 ## Disabling JMX
 Sometimes you want to globally disable JMX monitoring on the server. You can do that by setting system property `avastMetricsDisableJmx=true`. To do that from bash, you can use:

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val Versions = new {
   val grpc = "1.42.1"
   val slf4j = "1.7.30"
   val assertj = "3.12.2"
+  val catsEffect = "2.5.3"
 }
 
 lazy val commonSettings = Seq(
@@ -73,6 +74,18 @@ lazy val scalaApi = (project in file("scala-api"))
     name := "metrics-scala"
   )
   .dependsOn(api, jmx % "test")
+
+lazy val scalaEffectApi = (project in file("scala-effect-api"))
+  .settings(
+    commonSettings,
+    scalaSettings,
+    scalacOptions += "-language:higherKinds",
+    name := "metrics-scala-effect",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-effect" % Versions.catsEffect
+    )
+  )
+  .dependsOn(scalaApi, jmx % "test")
 
 lazy val core = (project in file("core"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val scalaEffectApi = (project in file("scala-effect-api"))
     commonSettings,
     scalaSettings,
     scalacOptions += "-language:higherKinds",
-    name := "metrics-scala-effect",
+    name := "metrics-cats-effect2",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-effect" % Versions.catsEffect
     )

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val Versions = new {
   val grpc = "1.42.1"
   val slf4j = "1.7.30"
   val assertj = "3.12.2"
-  val catsEffect = "2.5.3"
+  val catsEffect2 = "2.5.3"
 }
 
 lazy val commonSettings = Seq(
@@ -59,7 +59,7 @@ lazy val root = (project in file("."))
     publish / skip := true,
     crossScalaVersions := Nil
   )
-  .aggregate(api, scalaApi, core, dropwizardCommon, jmx, jmxAvast, graphite, filter, formatting, statsd, grpc)
+  .aggregate(api, scalaApi, scalaCatsEffect2, core, dropwizardCommon, jmx, jmxAvast, graphite, filter, formatting, statsd, grpc)
 
 lazy val api = (project in file("api")).settings(
   commonSettings,
@@ -75,14 +75,14 @@ lazy val scalaApi = (project in file("scala-api"))
   )
   .dependsOn(api, jmx % "test")
 
-lazy val scalaEffectApi = (project in file("scala-effect-api"))
+lazy val scalaCatsEffect2 = (project in file("scala-effect-api"))
   .settings(
     commonSettings,
     scalaSettings,
     scalacOptions += "-language:higherKinds",
-    name := "metrics-cats-effect2",
+    name := "metrics-cats-effect-2",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % Versions.catsEffect
+      "org.typelevel" %% "cats-effect" % Versions.catsEffect2
     )
   )
   .dependsOn(scalaApi, jmx % "test")

--- a/scala-api/src/main/scala/com/avast/metrics/scalaapi/Timer.scala
+++ b/scala-api/src/main/scala/com/avast/metrics/scalaapi/Timer.scala
@@ -1,14 +1,16 @@
 package com.avast.metrics.scalaapi
 
-import java.time.Duration
-
+import java.time.{Duration => JDuration}
 import com.avast.metrics.api.Timer.TimeContext
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 trait Timer extends Metric {
 
   def start(): TimeContext
+
+  def update(duration: JDuration): Unit
 
   def update(duration: Duration): Unit
 

--- a/scala-api/src/main/scala/com/avast/metrics/scalaapi/TimerPair.scala
+++ b/scala-api/src/main/scala/com/avast/metrics/scalaapi/TimerPair.scala
@@ -1,7 +1,7 @@
 package com.avast.metrics.scalaapi
 
-import java.time.Duration
-
+import java.time.{Duration => JDuration}
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 trait TimerPair {
@@ -12,6 +12,10 @@ trait TimerPair {
   }
 
   def start(): TimeContext
+
+  def update(duration: JDuration): Unit
+
+  def updateFailure(duration: JDuration): Unit
 
   def update(duration: Duration): Unit
 

--- a/scala-api/src/main/scala/com/avast/metrics/scalaapi/impl/TimerImpl.scala
+++ b/scala-api/src/main/scala/com/avast/metrics/scalaapi/impl/TimerImpl.scala
@@ -1,11 +1,11 @@
 package com.avast.metrics.scalaapi.impl
 
-import java.time.Duration
-
+import java.time.{Duration => JDuration}
 import com.avast.metrics.api.Timer.TimeContext
 import com.avast.metrics.api.{Timer => JTimer}
 import com.avast.metrics.scalaapi.Timer
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -13,7 +13,9 @@ private class TimerImpl(inner: JTimer) extends Timer {
 
   override def start(): TimeContext = inner.start()
 
-  override def update(duration: Duration): Unit = inner.update(duration)
+  override def update(duration: JDuration): Unit = inner.update(duration)
+
+  override def update(duration: Duration): Unit = update(JDuration.ofNanos(duration.toNanos))
 
   override def name: String = inner.getName
 

--- a/scala-api/src/main/scala/com/avast/metrics/scalaapi/impl/TimerPairImpl.scala
+++ b/scala-api/src/main/scala/com/avast/metrics/scalaapi/impl/TimerPairImpl.scala
@@ -1,9 +1,9 @@
 package com.avast.metrics.scalaapi.impl
 
-import java.time.Duration
-
+import java.time.{Duration => JDuration}
 import com.avast.metrics.scalaapi.{Timer, TimerPair}
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
@@ -20,6 +20,10 @@ private class TimerPairImpl(success: Timer, failure: Timer) extends TimerPair {
       override def stopFailure(): Unit = failCtx.stop()
     }
   }
+
+  override def update(duration: JDuration): Unit = success.update(duration)
+
+  override def updateFailure(duration: JDuration): Unit = failure.update(duration)
 
   override def update(duration: Duration): Unit = success.update(duration)
 

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Counter.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Counter.scala
@@ -1,0 +1,10 @@
+package com.avast.metrics.scalaeffectapi
+
+import com.avast.metrics.scalaapi.Metric
+
+trait Counter[F[_]] extends Counting[F] with Metric {
+  def inc: F[Unit]
+  def inc(n: Long): F[Unit]
+  def dec: F[Unit]
+  def dec(n: Int): F[Unit]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Counting.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Counting.scala
@@ -1,0 +1,5 @@
+package com.avast.metrics.scalaeffectapi
+
+trait Counting[F[_]] {
+  def count: F[Long]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Gauge.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Gauge.scala
@@ -1,0 +1,8 @@
+package com.avast.metrics.scalaeffectapi
+
+import com.avast.metrics.scalaapi.Metric
+
+trait Gauge[F[_], T] extends Metric {
+  def value: F[T]
+  def set(value: T): F[Unit]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/GaugeFactory.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/GaugeFactory.scala
@@ -1,0 +1,6 @@
+package com.avast.metrics.scalaeffectapi
+
+trait GaugeFactory[F[_]] {
+  def long(name: String): Gauge[F, Long]
+  def double(name: String): Gauge[F, Double]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Histogram.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Histogram.scala
@@ -1,0 +1,7 @@
+package com.avast.metrics.scalaeffectapi
+
+import com.avast.metrics.scalaapi.Metric
+
+trait Histogram[F[_]] extends Metric {
+  def update(value: Long): F[Unit]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Meter.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Meter.scala
@@ -1,0 +1,8 @@
+package com.avast.metrics.scalaeffectapi
+
+import com.avast.metrics.scalaapi.Metric
+
+trait Meter[F[_]] extends Counting[F] with Metric {
+  def mark: F[Unit]
+  def mark(n: Long): F[Unit]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
@@ -1,0 +1,46 @@
+package com.avast.metrics.scalaeffectapi
+
+import cats.effect.Sync
+import com.avast.metrics.api.{Monitor => JMonitor, Naming}
+import com.avast.metrics.scalaapi.{Monitor => SMonitor}
+import com.avast.metrics.test.NoOpMonitor
+
+trait Monitor[F[_]] extends AutoCloseable {
+  def named(name: String): Monitor[F]
+  def named(name1: String, name2: String, restOfNames: String*): Monitor[F]
+  def getName: String
+  def meter(name: String): Meter[F]
+  def counter(name: String): Counter[F]
+  def timer(name: String): Timer[F]
+  def timerPair(name: String): TimerPair[F]
+  def histogram(name: String): Histogram[F]
+
+  def gauge: GaugeFactory[F]
+
+  def asJava: JMonitor
+  def unwrap: SMonitor
+}
+
+object Monitor {
+
+  def apply[F[_]: Sync](monitor: JMonitor): F[Monitor[F]] = Sync[F].delay(applyUnsafe(monitor))
+  def apply[F[_]: Sync](monitor: JMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(applyUnsafe(monitor, naming))
+
+  def wrap[F[_]: Sync](monitor: SMonitor): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor))
+  def wrap[F[_]: Sync](monitor: SMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor, naming))
+
+  def applyUnsafe[F[_]: Sync](monitor: JMonitor): Monitor[F] = applyUnsafe(monitor, Naming.defaultNaming())
+  def applyUnsafe[F[_]: Sync](monitor: JMonitor, naming: Naming): Monitor[F] = wrapUnsafe(SMonitor(monitor), naming)
+
+  def wrapUnsafe[F[_]: Sync](monitor: SMonitor): Monitor[F] = wrapUnsafe(monitor, Naming.defaultNaming())
+  def wrapUnsafe[F[_]: Sync](monitor: SMonitor, naming: Naming): Monitor[F] = new impl.MonitorImpl(monitor, naming)
+
+  def noOp[F[_]: Sync](): F[Monitor[F]] = {
+    apply(NoOpMonitor.INSTANCE)
+  }
+
+  def noOpUnsafe[F[_]: Sync](): Monitor[F] = {
+    applyUnsafe(NoOpMonitor.INSTANCE)
+  }
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
@@ -23,24 +23,24 @@ trait Monitor[F[_]] extends AutoCloseable {
 
 object Monitor {
 
-  def apply[F[_]: Sync](monitor: JMonitor): F[Monitor[F]] = Sync[F].delay(applyUnsafe(monitor))
-  def apply[F[_]: Sync](monitor: JMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(applyUnsafe(monitor, naming))
+  def wrapJava[F[_]: Sync](monitor: JMonitor): F[Monitor[F]] = Sync[F].delay(wrapJavaUnsafe(monitor))
+  def wrapJava[F[_]: Sync](monitor: JMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(wrapJavaUnsafe(monitor, naming))
 
   def wrap[F[_]: Sync](monitor: SMonitor): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor))
   def wrap[F[_]: Sync](monitor: SMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor, naming))
 
-  def applyUnsafe[F[_]: Sync](monitor: JMonitor): Monitor[F] = applyUnsafe(monitor, Naming.defaultNaming())
-  def applyUnsafe[F[_]: Sync](monitor: JMonitor, naming: Naming): Monitor[F] = wrapUnsafe(SMonitor(monitor), naming)
+  def wrapJavaUnsafe[F[_]: Sync](monitor: JMonitor): Monitor[F] = wrapJavaUnsafe(monitor, Naming.defaultNaming())
+  def wrapJavaUnsafe[F[_]: Sync](monitor: JMonitor, naming: Naming): Monitor[F] = wrapUnsafe(SMonitor(monitor), naming)
 
   def wrapUnsafe[F[_]: Sync](monitor: SMonitor): Monitor[F] = wrapUnsafe(monitor, Naming.defaultNaming())
   def wrapUnsafe[F[_]: Sync](monitor: SMonitor, naming: Naming): Monitor[F] = new impl.MonitorImpl(monitor, naming)
 
   def noOp[F[_]: Sync](): F[Monitor[F]] = {
-    apply(NoOpMonitor.INSTANCE)
+    wrapJava(NoOpMonitor.INSTANCE)
   }
 
   def noOpUnsafe[F[_]: Sync](): Monitor[F] = {
-    applyUnsafe(NoOpMonitor.INSTANCE)
+    wrapJavaUnsafe(NoOpMonitor.INSTANCE)
   }
 
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Monitor.scala
@@ -23,24 +23,14 @@ trait Monitor[F[_]] extends AutoCloseable {
 
 object Monitor {
 
-  def wrapJava[F[_]: Sync](monitor: JMonitor): F[Monitor[F]] = Sync[F].delay(wrapJavaUnsafe(monitor))
-  def wrapJava[F[_]: Sync](monitor: JMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(wrapJavaUnsafe(monitor, naming))
+  def wrapJava[F[_]: Sync](monitor: JMonitor): Monitor[F] = wrapJava(monitor, Naming.defaultNaming())
+  def wrapJava[F[_]: Sync](monitor: JMonitor, naming: Naming): Monitor[F] = wrap(SMonitor(monitor), naming)
 
-  def wrap[F[_]: Sync](monitor: SMonitor): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor))
-  def wrap[F[_]: Sync](monitor: SMonitor, naming: Naming): F[Monitor[F]] = Sync[F].delay(wrapUnsafe(monitor, naming))
+  def wrap[F[_]: Sync](monitor: SMonitor): Monitor[F] = wrap(monitor, Naming.defaultNaming())
+  def wrap[F[_]: Sync](monitor: SMonitor, naming: Naming): Monitor[F] = new impl.MonitorImpl(monitor, naming)
 
-  def wrapJavaUnsafe[F[_]: Sync](monitor: JMonitor): Monitor[F] = wrapJavaUnsafe(monitor, Naming.defaultNaming())
-  def wrapJavaUnsafe[F[_]: Sync](monitor: JMonitor, naming: Naming): Monitor[F] = wrapUnsafe(SMonitor(monitor), naming)
-
-  def wrapUnsafe[F[_]: Sync](monitor: SMonitor): Monitor[F] = wrapUnsafe(monitor, Naming.defaultNaming())
-  def wrapUnsafe[F[_]: Sync](monitor: SMonitor, naming: Naming): Monitor[F] = new impl.MonitorImpl(monitor, naming)
-
-  def noOp[F[_]: Sync](): F[Monitor[F]] = {
+  def noOp[F[_]: Sync](): Monitor[F] = {
     wrapJava(NoOpMonitor.INSTANCE)
-  }
-
-  def noOpUnsafe[F[_]: Sync](): Monitor[F] = {
-    wrapJavaUnsafe(NoOpMonitor.INSTANCE)
   }
 
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -1,8 +1,5 @@
 package com.avast.metrics.scalaeffectapi
 
-import cats.Monad
-import cats.syntax.flatMap._
-import cats.syntax.functor._
 import com.avast.metrics.api.Timer.TimeContext
 
 import java.time.Duration
@@ -10,18 +7,5 @@ import java.time.Duration
 trait Timer[F[_]] {
   def start: F[TimeContext]
   def stop(context: TimeContext): F[Duration]
-}
-
-object Timer {
-  object Dsl {
-    implicit class TimerOps[F[_]](val timer: Timer[F]) extends AnyVal {
-      def time[A](block: F[A])(implicit monad: Monad[F]): F[A] = {
-        for {
-          context <- timer.start
-          result <- block
-          _ <- timer.stop(context)
-        } yield result
-      }
-    }
-  }
+  def time[A](block: F[A]): F[A]
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -3,12 +3,13 @@ package com.avast.metrics.scalaeffectapi
 import cats.Monad
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+import com.avast.metrics.api.Timer.TimeContext
+
 import java.time.Duration
 
 trait Timer[F[_]] {
-  type Context
-  def start: F[Context]
-  def stop(context: Context): F[Duration]
+  def start: F[TimeContext]
+  def stop(context: TimeContext): F[Duration]
 }
 
 object Timer {

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -2,11 +2,13 @@ package com.avast.metrics.scalaeffectapi
 
 import com.avast.metrics.api.Timer.TimeContext
 
-import java.time.Duration
+import java.time.{Duration => JDuration}
+import scala.concurrent.duration.Duration
 
 trait Timer[F[_]] {
   def start: F[TimeContext]
   def stop(context: TimeContext): F[Duration]
+  def update(duration: JDuration): F[Unit]
   def update(duration: Duration): F[Unit]
   def time[A](block: F[A]): F[A]
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -7,5 +7,6 @@ import java.time.Duration
 trait Timer[F[_]] {
   def start: F[TimeContext]
   def stop(context: TimeContext): F[Duration]
+  def update(duration: Duration): F[Unit]
   def time[A](block: F[A]): F[A]
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -1,0 +1,26 @@
+package com.avast.metrics.scalaeffectapi
+
+import cats.Monad
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import java.time.Duration
+
+trait Timer[F[_]] {
+  type Context
+  def start: F[Context]
+  def stop(context: Context): F[Duration]
+}
+
+object Timer {
+  object Dsl {
+    implicit class TimerOps[F[_]](val timer: Timer[F]) extends AnyVal {
+      def time[A](block: F[A])(implicit monad: Monad[F]): F[A] = {
+        for {
+          context <- timer.start
+          result <- block
+          _ <- timer.stop(context)
+        } yield result
+      }
+    }
+  }
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/Timer.scala
@@ -1,13 +1,14 @@
 package com.avast.metrics.scalaeffectapi
 
-import com.avast.metrics.api.Timer.TimeContext
-
 import java.time.{Duration => JDuration}
 import scala.concurrent.duration.Duration
 
 trait Timer[F[_]] {
+  trait TimeContext extends AutoCloseable {
+    def stop: F[Duration]
+  }
+
   def start: F[TimeContext]
-  def stop(context: TimeContext): F[Duration]
   def update(duration: JDuration): F[Unit]
   def update(duration: Duration): F[Unit]
   def time[A](block: F[A]): F[A]

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -1,0 +1,27 @@
+package com.avast.metrics.scalaeffectapi
+
+import cats.effect.{ExitCase, Resource, Sync}
+import cats.syntax.functor._
+
+import java.time.Duration
+
+trait TimerPair[F[_]] {
+  type Context
+  def start: F[Context]
+  def stop(context: Context): F[Duration]
+  def stopFailure(context: Context): F[Duration]
+}
+
+object TimerPair {
+  object Dsl {
+    implicit class TimerPairOps[F[_]](val timerPair: TimerPair[F]) extends AnyVal {
+      def time[T](action: F[T])(implicit sync: Sync[F]): F[T] = {
+        Resource
+          .makeCase(timerPair.start) {
+            case (ctx, ExitCase.Completed) => timerPair.stop(ctx).as(())
+            case (ctx, _) => timerPair.stopFailure(ctx).as(())
+          }
+      }.use(_ => action)
+    }
+  }
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -4,7 +4,7 @@ import java.time.{Duration => JDuration}
 import scala.concurrent.duration.Duration
 
 trait TimerPair[F[_]] {
-  trait TimerPairContext {
+  trait TimerPairContext extends AutoCloseable {
     def stop: F[Duration]
     def stopFailure: F[Duration]
   }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -1,6 +1,7 @@
 package com.avast.metrics.scalaeffectapi
 
-import java.time.Duration
+import java.time.{Duration => JDuration}
+import scala.concurrent.duration.Duration
 
 trait TimerPair[F[_]] {
   trait TimerPairContext {
@@ -9,6 +10,8 @@ trait TimerPair[F[_]] {
   }
 
   def start: F[TimerPairContext]
+  def update(duration: JDuration): F[Unit]
+  def updateFailure(duration: JDuration): F[Unit]
   def update(duration: Duration): F[Unit]
   def updateFailure(duration: Duration): F[Unit]
   def time[T](action: F[T]): F[T]

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -1,8 +1,5 @@
 package com.avast.metrics.scalaeffectapi
 
-import cats.effect.{ExitCase, Resource, Sync}
-import cats.syntax.functor._
-
 import java.time.Duration
 
 trait TimerPair[F[_]] {
@@ -14,18 +11,5 @@ trait TimerPair[F[_]] {
   def start: F[TimerPairContext]
   def stop(context: TimerPairContext): F[Duration]
   def stopFailure(context: TimerPairContext): F[Duration]
-}
-
-object TimerPair {
-  object Dsl {
-    implicit class TimerPairOps[F[_]](val timerPair: TimerPair[F]) extends AnyVal {
-      def time[T](action: F[T])(implicit sync: Sync[F]): F[T] = {
-        Resource
-          .makeCase(timerPair.start) {
-            case (ctx, ExitCase.Completed) => timerPair.stop(ctx).as(())
-            case (ctx, _) => timerPair.stopFailure(ctx).as(())
-          }
-      }.use(_ => action)
-    }
-  }
+  def time[T](action: F[T]): F[T]
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -9,7 +9,7 @@ trait TimerPair[F[_]] {
   }
 
   def start: F[TimerPairContext]
-  def stop(context: TimerPairContext): F[Duration]
-  def stopFailure(context: TimerPairContext): F[Duration]
+  def update(duration: Duration): F[Unit]
+  def updateFailure(duration: Duration): F[Unit]
   def time[T](action: F[T]): F[T]
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPair.scala
@@ -6,10 +6,14 @@ import cats.syntax.functor._
 import java.time.Duration
 
 trait TimerPair[F[_]] {
-  type Context
-  def start: F[Context]
-  def stop(context: Context): F[Duration]
-  def stopFailure(context: Context): F[Duration]
+  trait TimerPairContext {
+    def stop: F[Duration]
+    def stopFailure: F[Duration]
+  }
+
+  def start: F[TimerPairContext]
+  def stop(context: TimerPairContext): F[Duration]
+  def stopFailure(context: TimerPairContext): F[Duration]
 }
 
 object TimerPair {

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPairContext.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPairContext.scala
@@ -1,0 +1,8 @@
+package com.avast.metrics.scalaeffectapi
+
+import java.time.Duration
+
+trait TimerPairContext[F[_]] {
+  def stop: F[Duration]
+  def stopFailure: F[Duration]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPairContext.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/TimerPairContext.scala
@@ -1,8 +1,0 @@
-package com.avast.metrics.scalaeffectapi
-
-import java.time.Duration
-
-trait TimerPairContext[F[_]] {
-  def stop: F[Duration]
-  def stopFailure: F[Duration]
-}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/CounterImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/CounterImpl.scala
@@ -1,0 +1,19 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.scalaapi.{Counter => SCounter}
+import com.avast.metrics.scalaeffectapi.Counter
+
+private class CounterImpl[F[_]: Sync](inner: SCounter) extends Counter[F] {
+  override def inc: F[Unit] = Sync[F].delay(inner.inc())
+
+  override def inc(n: Long): F[Unit] = Sync[F].delay(inner.inc(n))
+
+  override def dec: F[Unit] = Sync[F].delay(inner.dec())
+
+  override def dec(n: Int): F[Unit] = Sync[F].delay(inner.dec(n))
+
+  override def count: F[Long] = Sync[F].delay(inner.count)
+
+  override def name: String = inner.name
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/GaugeFactoryImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/GaugeFactoryImpl.scala
@@ -1,0 +1,30 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.scalaapi.{Monitor => SMonitor}
+import com.avast.metrics.scalaeffectapi.{Gauge, GaugeFactory}
+
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+
+private class GaugeFactoryImpl[F[_]: Sync](monitor: SMonitor) extends GaugeFactory[F] {
+  override def long(name: String): Gauge[F, Long] = new Gauge[F, Long] {
+    private[this] val valueRef = new AtomicLong()
+    private[this] val gauge = monitor.gauge(name)(() => valueRef.get())
+    override def set(value: Long): F[Unit] = Sync[F].delay(valueRef.set(value))
+
+    override def name: String = gauge.name
+
+    override def value: F[Long] = Sync[F].delay(gauge.value)
+  }
+
+  override def double(name: String): Gauge[F, Double] = new Gauge[F, Double] {
+    private[this] val valueRef = new AtomicReference(0.0)
+    private[this] val gauge = monitor.gauge(name)(() => valueRef.get())
+    override def set(value: Double): F[Unit] = Sync[F].delay(valueRef.set(value))
+
+    override def name: String = gauge.name
+
+    override def value: F[Double] = Sync[F].delay(gauge.value)
+  }
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/GaugeFactoryImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/GaugeFactoryImpl.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 private class GaugeFactoryImpl[F[_]: Sync](monitor: SMonitor) extends GaugeFactory[F] {
   override def long(name: String): Gauge[F, Long] = new Gauge[F, Long] {
     private[this] val valueRef = new AtomicLong()
-    private[this] val gauge = monitor.gauge(name)(() => valueRef.get())
+    private[this] val gauge = monitor.gauge(name)(valueRef.get)
     override def set(value: Long): F[Unit] = Sync[F].delay(valueRef.set(value))
 
     override def name: String = gauge.name
@@ -19,7 +19,7 @@ private class GaugeFactoryImpl[F[_]: Sync](monitor: SMonitor) extends GaugeFacto
 
   override def double(name: String): Gauge[F, Double] = new Gauge[F, Double] {
     private[this] val valueRef = new AtomicReference(0.0)
-    private[this] val gauge = monitor.gauge(name)(() => valueRef.get())
+    private[this] val gauge = monitor.gauge(name)(valueRef.get)
     override def set(value: Double): F[Unit] = Sync[F].delay(valueRef.set(value))
 
     override def name: String = gauge.name

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/HistogramImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/HistogramImpl.scala
@@ -1,0 +1,11 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.scalaapi.{Histogram => SHistogram}
+import com.avast.metrics.scalaeffectapi.Histogram
+
+private class HistogramImpl[F[_]: Sync](histogram: SHistogram) extends Histogram[F] {
+  override def update(value: Long): F[Unit] = Sync[F].delay(histogram.update(value))
+
+  override def name: String = histogram.name
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/MeterImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/MeterImpl.scala
@@ -1,0 +1,15 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.scalaapi.{Meter => SMeter}
+import com.avast.metrics.scalaeffectapi.Meter
+
+private class MeterImpl[F[_]: Sync](meter: SMeter) extends Meter[F] {
+  override def mark: F[Unit] = Sync[F].delay(meter.mark())
+
+  override def mark(n: Long): F[Unit] = Sync[F].delay(meter.mark(n))
+
+  override def count: F[Long] = Sync[F].delay(meter.count)
+
+  override def name: String = meter.name
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/MonitorImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/MonitorImpl.scala
@@ -1,0 +1,37 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.api.{Monitor => JMonitor, Naming}
+
+import com.avast.metrics.scalaapi.{Monitor => SMonitor}
+import com.avast.metrics.scalaeffectapi._
+
+private[scalaeffectapi] class MonitorImpl[F[_]: Sync](monitor: SMonitor, naming: Naming) extends Monitor[F] {
+
+  override def named(name: String): Monitor[F] = new MonitorImpl(monitor.named(name), naming)
+
+  override def named(name: String, name2: String, names: String*): Monitor[F] =
+    new MonitorImpl(monitor.named(name, name2, names: _*), naming)
+
+  override def getName: String = monitor.getName
+
+  override def meter(name: String): Meter[F] = new MeterImpl[F](monitor.meter(name))
+
+  override def counter(name: String): Counter[F] = new CounterImpl(monitor.counter(name))
+
+  override def timer(name: String): Timer[F] = new TimerImpl(monitor.timer(name))
+
+  override def timerPair(name: String): TimerPair[F] =
+    new TimerPairImpl(timer(naming.successTimerName(name)), timer(naming.failureTimerName(name)))
+
+  override def histogram(name: String): Histogram[F] = new HistogramImpl(monitor.histogram(name))
+
+  override def gauge: GaugeFactory[F] = new GaugeFactoryImpl(monitor)
+
+  override def close(): Unit = monitor.close()
+
+  override def asJava: JMonitor = monitor.asJava
+
+  override def unwrap: SMonitor = monitor
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -8,9 +8,7 @@ import com.avast.metrics.scalaapi.{Timer => STimer}
 import com.avast.metrics.scalaeffectapi.Timer
 
 private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
-  override type Context = TimeContext
+  override def start: F[TimeContext] = Sync[F].delay(inner.start())
 
-  override def start: F[Context] = Sync[F].delay(inner.start())
-
-  override def stop(context: Context): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
+  override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -1,0 +1,16 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import com.avast.metrics.api.Timer.TimeContext
+
+import java.time.Duration
+import com.avast.metrics.scalaapi.{Timer => STimer}
+import com.avast.metrics.scalaeffectapi.Timer
+
+private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
+  override type Context = TimeContext
+
+  override def start: F[Context] = Sync[F].delay(inner.start())
+
+  override def stop(context: Context): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -1,6 +1,8 @@
 package com.avast.metrics.scalaeffectapi.impl
 
 import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
 import com.avast.metrics.api.Timer.TimeContext
 
 import java.time.Duration
@@ -11,4 +13,12 @@ private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
   override def start: F[TimeContext] = Sync[F].delay(inner.start())
 
   override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
+
+  override def time[A](block: F[A]): F[A] = {
+    for {
+      context <- start
+      result <- block
+      _ <- stop(context)
+    } yield result
+  }
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -3,7 +3,6 @@ package com.avast.metrics.scalaeffectapi.impl
 import cats.effect.Sync
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import com.avast.metrics.api.Timer.TimeContext
 
 import java.time.{Duration => JDuration}
 import com.avast.metrics.scalaapi.{Timer => STimer}
@@ -12,9 +11,14 @@ import com.avast.metrics.scalaeffectapi.Timer
 import scala.concurrent.duration.Duration
 
 private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
-  override def start: F[TimeContext] = Sync[F].delay(inner.start())
+  override def start: F[TimeContext] = Sync[F].delay {
+    val context = inner.start()
+    new TimeContext {
+      override def stop: F[Duration] = Sync[F].delay(Duration.fromNanos(context.stopAndGetTime()))
 
-  override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.fromNanos(context.stopAndGetTime()))
+      override def close(): Unit = context.close()
+    }
+  }
 
   override def update(duration: JDuration): F[Unit] = Sync[F].delay(inner.update(duration))
 
@@ -24,7 +28,7 @@ private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
     for {
       context <- start
       result <- block
-      _ <- stop(context)
+      _ <- context.stop
     } yield result
   }
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -5,16 +5,20 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.avast.metrics.api.Timer.TimeContext
 
-import java.time.Duration
+import java.time.{Duration => JDuration}
 import com.avast.metrics.scalaapi.{Timer => STimer}
 import com.avast.metrics.scalaeffectapi.Timer
+
+import scala.concurrent.duration.Duration
 
 private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
   override def start: F[TimeContext] = Sync[F].delay(inner.start())
 
-  override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
+  override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.fromNanos(context.stopAndGetTime()))
 
-  override def update(duration: Duration): F[Unit] = Sync[F].delay(inner.update(duration))
+  override def update(duration: JDuration): F[Unit] = Sync[F].delay(inner.update(duration))
+
+  override def update(duration: Duration): F[Unit] = update(JDuration.ofNanos(duration.toNanos))
 
   override def time[A](block: F[A]): F[A] = {
     for {

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerImpl.scala
@@ -14,6 +14,8 @@ private class TimerImpl[F[_]: Sync](inner: STimer) extends Timer[F] {
 
   override def stop(context: TimeContext): F[Duration] = Sync[F].delay(Duration.ofNanos(context.stopAndGetTime()))
 
+  override def update(duration: Duration): F[Unit] = Sync[F].delay(inner.update(duration))
+
   override def time[A](block: F[A]): F[A] = {
     for {
       context <- start

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -19,16 +19,15 @@ private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) ex
     }
   }
 
-  override def stop(context: TimerPairContext): F[Duration] = context.stop
+  override def update(duration: Duration): F[Unit] = Sync[F].delay(success.update(duration))
 
-  override def stopFailure(context: TimerPairContext): F[Duration] = context.stopFailure
+  override def updateFailure(duration: Duration): F[Unit] = Sync[F].delay(failure.update(duration))
 
   override def time[T](action: F[T]): F[T] = {
     Resource
       .makeCase(start) {
-        case (ctx, ExitCase.Completed) => stop(ctx).as(())
-        case (ctx, _) => stopFailure(ctx).as(())
+        case (ctx, ExitCase.Completed) => ctx.stop.as(())
+        case (ctx, _) => ctx.stopFailure.as(())
       }
   }.use(_ => action)
-
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -4,8 +4,10 @@ import cats.effect.{ExitCase, Resource, Sync}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
-import java.time.Duration
+import java.time.{Duration => JDuration}
 import com.avast.metrics.scalaeffectapi.{Timer, TimerPair}
+
+import scala.concurrent.duration.Duration
 
 private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) extends TimerPair[F] {
   override def start: F[TimerPairContext] = {
@@ -18,6 +20,10 @@ private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) ex
       override def stopFailure: F[Duration] = failure.stop(failCtx)
     }
   }
+
+  override def update(duration: JDuration): F[Unit] = Sync[F].delay(success.update(duration))
+
+  override def updateFailure(duration: JDuration): F[Unit] = Sync[F].delay(failure.update(duration))
 
   override def update(duration: Duration): F[Unit] = Sync[F].delay(success.update(duration))
 

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -15,9 +15,14 @@ private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) ex
       succCtx <- success.start
       failCtx <- failure.start
     } yield new TimerPairContext {
-      override def stop: F[Duration] = success.stop(succCtx)
+      override def stop: F[Duration] = succCtx.stop
 
-      override def stopFailure: F[Duration] = failure.stop(failCtx)
+      override def stopFailure: F[Duration] = failCtx.stop
+
+      override def close(): Unit = {
+        succCtx.close()
+        failCtx.close()
+      }
     }
   }
 

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -1,0 +1,28 @@
+package com.avast.metrics.scalaeffectapi.impl
+
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+import java.time.Duration
+import com.avast.metrics.scalaeffectapi.{Timer, TimerPair, TimerPairContext}
+
+private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) extends TimerPair[F] {
+  override type Context = TimerPairContext[F]
+
+  override def start: F[Context] = {
+    for {
+      succCtx <- success.start
+      failCtx <- failure.start
+    } yield new Context {
+      override def stop: F[Duration] = success.stop(succCtx)
+
+      override def stopFailure: F[Duration] = failure.stop(failCtx)
+    }
+  }
+
+  override def stop(context: Context): F[Duration] = context.stop
+
+  override def stopFailure(context: Context): F[Duration] = context.stopFailure
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -5,24 +5,22 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 
 import java.time.Duration
-import com.avast.metrics.scalaeffectapi.{Timer, TimerPair, TimerPairContext}
+import com.avast.metrics.scalaeffectapi.{Timer, TimerPair}
 
 private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) extends TimerPair[F] {
-  override type Context = TimerPairContext[F]
-
-  override def start: F[Context] = {
+  override def start: F[TimerPairContext] = {
     for {
       succCtx <- success.start
       failCtx <- failure.start
-    } yield new Context {
+    } yield new TimerPairContext {
       override def stop: F[Duration] = success.stop(succCtx)
 
       override def stopFailure: F[Duration] = failure.stop(failCtx)
     }
   }
 
-  override def stop(context: Context): F[Duration] = context.stop
+  override def stop(context: TimerPairContext): F[Duration] = context.stop
 
-  override def stopFailure(context: Context): F[Duration] = context.stopFailure
+  override def stopFailure(context: TimerPairContext): F[Duration] = context.stopFailure
 
 }

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyGaugeFactory.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyGaugeFactory.scala
@@ -1,0 +1,8 @@
+package com.avast.metrics.scalaeffectapi.perkey
+
+import com.avast.metrics.scalaeffectapi.Gauge
+
+trait PerKeyGaugeFactory[F[_]] {
+  def long(baseName: String): PerKeyMetric[Gauge[F, Long]]
+  def double(baseName: String): PerKeyMetric[Gauge[F, Double]]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyMetric.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyMetric.scala
@@ -1,0 +1,5 @@
+package com.avast.metrics.scalaeffectapi.perkey
+
+trait PerKeyMetric[M] {
+  def forKey(str: String): M
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyMonitor.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyMonitor.scala
@@ -1,0 +1,13 @@
+package com.avast.metrics.scalaeffectapi.perkey
+
+import com.avast.metrics.scalaeffectapi.Monitor
+import com.avast.metrics.scalaeffectapi.perkey.impl.{PerKeyMonitorImpl, PerKeyOpsImpl}
+
+trait PerKeyMonitor[F[_]] extends Monitor[F] {
+  def perKey: PerKeyOps[F]
+}
+
+object PerKeyMonitor {
+  def apply[F[_]](monitor: Monitor[F]): PerKeyMonitor[F] =
+    new PerKeyMonitorImpl(monitor, new PerKeyOpsImpl(monitor))
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyOps.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/PerKeyOps.scala
@@ -1,0 +1,12 @@
+package com.avast.metrics.scalaeffectapi.perkey
+
+import com.avast.metrics.scalaeffectapi._
+
+trait PerKeyOps[F[_]] {
+  def meter(name: String): PerKeyMetric[Meter[F]]
+  def counter(name: String): PerKeyMetric[Counter[F]]
+  def timer(name: String): PerKeyMetric[Timer[F]]
+  def timerPair(name: String): PerKeyMetric[TimerPair[F]]
+  def histogram(name: String): PerKeyMetric[Histogram[F]]
+  def gauge: PerKeyGaugeFactory[F]
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyGaugeFactoryImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyGaugeFactoryImpl.scala
@@ -1,0 +1,20 @@
+package com.avast.metrics.scalaeffectapi.perkey.impl
+
+import com.avast.metrics.scalaeffectapi.{Gauge, Monitor}
+import com.avast.metrics.scalaeffectapi.perkey.{PerKeyGaugeFactory, PerKeyMetric}
+
+import scala.collection.concurrent.TrieMap
+
+class PerKeyGaugeFactoryImpl[F[_]](monitor: Monitor[F]) extends PerKeyGaugeFactory[F] {
+  private def emptyMap[M] = TrieMap.empty[String, M]
+
+  override def long(baseName: String): PerKeyMetric[Gauge[F, Long]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Gauge[F, Long]](emptyMap[Gauge[F, Long]], instanceBuilder.gauge.long)
+  }
+
+  override def double(baseName: String): PerKeyMetric[Gauge[F, Double]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Gauge[F, Double]](emptyMap[Gauge[F, Double]], instanceBuilder.gauge.double)
+  }
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyMetricImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyMetricImpl.scala
@@ -1,0 +1,11 @@
+package com.avast.metrics.scalaeffectapi.perkey.impl
+
+import com.avast.metrics.scalaeffectapi.perkey.PerKeyMetric
+
+import scala.collection.concurrent.{Map => CMap}
+
+private[perkey] class PerKeyMetricImpl[A](map: CMap[String, A], metricBuilder: String => A) extends PerKeyMetric[A] {
+  override def forKey(str: String): A = {
+    map.getOrElseUpdate(str, metricBuilder(str))
+  }
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyMonitorImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyMonitorImpl.scala
@@ -1,0 +1,36 @@
+package com.avast.metrics.scalaeffectapi.perkey.impl
+
+import com.avast.metrics.{api, scalaapi}
+import com.avast.metrics.scalaeffectapi._
+import com.avast.metrics.scalaeffectapi.perkey.{PerKeyMonitor, PerKeyOps}
+
+/** Adds `perKey` method, otherwise just forward method calls to [[com.avast.metrics.scalaeffectapi.Monitor]]
+  */
+private[perkey] class PerKeyMonitorImpl[F[_]](monitor: Monitor[F], perKeyOps: PerKeyOps[F]) extends PerKeyMonitor[F] {
+  override def perKey: PerKeyOps[F] = perKeyOps
+
+  override def named(name: String): Monitor[F] = monitor.named(name)
+
+  override def named(name: String, name2: String, names: String*): Monitor[F] = monitor.named(name, name2, names: _*)
+
+  override def getName: String = monitor.getName
+
+  override def meter(name: String): Meter[F] = monitor.meter(name)
+
+  override def counter(name: String): Counter[F] = monitor.counter(name)
+
+  override def timer(name: String): Timer[F] = monitor.timer(name)
+
+  override def timerPair(name: String): TimerPair[F] = monitor.timerPair(name)
+
+  override def histogram(name: String): Histogram[F] = monitor.histogram(name)
+
+  override def gauge: GaugeFactory[F] = monitor.gauge
+
+  override def close(): Unit = monitor.close()
+
+  override def asJava: api.Monitor = monitor.asJava
+
+  override def unwrap: scalaapi.Monitor = monitor.unwrap
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyOpsImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/impl/PerKeyOpsImpl.scala
@@ -1,0 +1,40 @@
+package com.avast.metrics.scalaeffectapi.perkey.impl
+
+import com.avast.metrics.scalaeffectapi._
+import com.avast.metrics.scalaeffectapi.perkey.{PerKeyGaugeFactory, PerKeyMetric, PerKeyOps}
+
+import scala.collection.concurrent.TrieMap
+
+private[perkey] class PerKeyOpsImpl[F[_]](monitor: Monitor[F]) extends PerKeyOps[F] {
+  private def emptyMap[M] = TrieMap.empty[String, M]
+
+  override def meter(baseName: String): PerKeyMetric[Meter[F]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Meter[F]](emptyMap[Meter[F]], instanceBuilder.meter)
+  }
+
+  override def counter(baseName: String): PerKeyMetric[Counter[F]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Counter[F]](emptyMap, instanceBuilder.counter)
+  }
+
+  override def timer(baseName: String): PerKeyMetric[Timer[F]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Timer[F]](emptyMap, instanceBuilder.timer)
+  }
+
+  override def timerPair(baseName: String): PerKeyMetric[TimerPair[F]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[TimerPair[F]](emptyMap, instanceBuilder.timerPair)
+  }
+
+  override def histogram(baseName: String): PerKeyMetric[Histogram[F]] = {
+    val instanceBuilder = monitor.named(baseName)
+    new PerKeyMetricImpl[Histogram[F]](emptyMap, instanceBuilder.histogram)
+  }
+
+  override def gauge: PerKeyGaugeFactory[F] = {
+    new PerKeyGaugeFactoryImpl[F](monitor)
+  }
+
+}

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/package.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/perkey/package.scala
@@ -1,0 +1,7 @@
+package com.avast.metrics.scalaeffectapi
+
+package object perkey {
+  implicit class MonitorToPerKeyOps[F[_]](monitor: Monitor[F]) {
+    def perKey: PerKeyOps[F] = PerKeyMonitor(monitor).perKey
+  }
+}

--- a/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
+++ b/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
@@ -3,7 +3,6 @@ package com.avast.metrics.examples
 import cats.effect.{ExitCode, IO, IOApp, Timer}
 import com.avast.metrics.dropwizard.JmxMetricsMonitor
 import com.avast.metrics.scalaeffectapi.Monitor
-import com.avast.metrics.scalaeffectapi.Timer.Dsl.TimerOps
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
@@ -14,7 +13,7 @@ object EffectMonitor extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     for {
-      monitor <- Monitor[IO](jmxMetricsMonitor)
+      monitor <- Monitor.wrapJava[IO](jmxMetricsMonitor)
       counter = monitor.counter("counter")
       _ <- counter.inc
       timer = monitor.timer("timer")

--- a/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
+++ b/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
@@ -12,11 +12,12 @@ object EffectMonitor extends IOApp {
   val jmxMetricsMonitor = new JmxMetricsMonitor("com.avast.some.app")
 
   override def run(args: List[String]): IO[ExitCode] = {
+    val monitor = Monitor.wrapJava[IO](jmxMetricsMonitor)
+    val counter = monitor.counter("counter")
+    val timer = monitor.timer("timer")
+
     for {
-      monitor <- Monitor.wrapJava[IO](jmxMetricsMonitor)
-      counter = monitor.counter("counter")
       _ <- counter.inc
-      timer = monitor.timer("timer")
       _ <- timer.time {
         Timer[IO](IO.timer(executionContext)).sleep(FiniteDuration(500, TimeUnit.MILLISECONDS))
       }

--- a/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
+++ b/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
@@ -1,0 +1,26 @@
+package com.avast.metrics.examples
+
+import cats.effect.{ExitCode, IO, IOApp, Timer}
+import com.avast.metrics.dropwizard.JmxMetricsMonitor
+import com.avast.metrics.scalaeffectapi.Monitor
+import com.avast.metrics.scalaeffectapi.Timer.Dsl.TimerOps
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+object EffectMonitor extends IOApp {
+
+  val jmxMetricsMonitor = new JmxMetricsMonitor("com.avast.some.app")
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    for {
+      monitor <- Monitor[IO](jmxMetricsMonitor)
+      counter = monitor.counter("counter")
+      _ <- counter.inc
+      timer = monitor.timer("timer")
+      _ <- timer.time {
+        Timer[IO](IO.timer(executionContext)).sleep(FiniteDuration(500, TimeUnit.MILLISECONDS))
+      }
+    } yield ExitCode.Success
+  }
+}


### PR DESCRIPTION
This PR has the ambition to add effect friendly metric API for simple usage with different frameworks.

Usage example can be found at `scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala`