### PR TITLE
Switch to Cats-Effect 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Main advantages of this library:
 1) Universal abstraction with misc. implementations
 2) Support of multiple exports at once (`MultiMonitor`)
 3) Scala API
-4) Scala Effect API (cats-effect 2)
+4) Scala Effect API (cats-effect 3) - If you need cats-effect 2 you can use version 2.9.0 of this library.
 
 The entry-point into the library is the interface `Monitor`. Your classes need to get an instance of a monitor which they can use to construct different metrics, e.g. meters, timers or histograms.
 Instances of the individuals metrics can be used to monitor your application.

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val Versions = new {
   val grpc = "1.42.1"
   val slf4j = "1.7.30"
   val assertj = "3.12.2"
-  val catsEffect2 = "2.5.3"
+  val catsEffect3 = "3.3.5"
 }
 
 lazy val commonSettings = Seq(
@@ -59,7 +59,7 @@ lazy val root = (project in file("."))
     publish / skip := true,
     crossScalaVersions := Nil
   )
-  .aggregate(api, scalaApi, scalaCatsEffect2, core, dropwizardCommon, jmx, jmxAvast, graphite, filter, formatting, statsd, grpc)
+  .aggregate(api, scalaApi, scalaCatsEffect3, core, dropwizardCommon, jmx, jmxAvast, graphite, filter, formatting, statsd, grpc)
 
 lazy val api = (project in file("api")).settings(
   commonSettings,
@@ -75,14 +75,14 @@ lazy val scalaApi = (project in file("scala-api"))
   )
   .dependsOn(api, jmx % "test")
 
-lazy val scalaCatsEffect2 = (project in file("scala-effect-api"))
+lazy val scalaCatsEffect3 = (project in file("scala-effect-api"))
   .settings(
     commonSettings,
     scalaSettings,
     scalacOptions += "-language:higherKinds",
-    name := "metrics-cats-effect-2",
+    name := "metrics-cats-effect-3",
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % Versions.catsEffect2
+      "org.typelevel" %% "cats-effect" % Versions.catsEffect3
     )
   )
   .dependsOn(scalaApi, jmx % "test")

--- a/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
+++ b/scala-effect-api/src/main/scala/com/avast/metrics/scalaeffectapi/impl/TimerPairImpl.scala
@@ -1,6 +1,6 @@
 package com.avast.metrics.scalaeffectapi.impl
 
-import cats.effect.{ExitCase, Resource, Sync}
+import cats.effect.{Resource, Sync}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -37,7 +37,7 @@ private class TimerPairImpl[F[_]: Sync](success: Timer[F], failure: Timer[F]) ex
   override def time[T](action: F[T]): F[T] = {
     Resource
       .makeCase(start) {
-        case (ctx, ExitCase.Completed) => ctx.stop.as(())
+        case (ctx, Resource.ExitCase.Succeeded) => ctx.stop.as(())
         case (ctx, _) => ctx.stopFailure.as(())
       }
   }.use(_ => action)

--- a/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
+++ b/scala-effect-api/src/test/scala/com/avast/metrics/examples/EffectMonitor.scala
@@ -1,6 +1,6 @@
 package com.avast.metrics.examples
 
-import cats.effect.{ExitCode, IO, IOApp, Timer}
+import cats.effect.{ExitCode, IO, IOApp}
 import com.avast.metrics.dropwizard.JmxMetricsMonitor
 import com.avast.metrics.scalaeffectapi.Monitor
 
@@ -19,7 +19,7 @@ object EffectMonitor extends IOApp {
     for {
       _ <- counter.inc
       _ <- timer.time {
-        Timer[IO](IO.timer(executionContext)).sleep(FiniteDuration(500, TimeUnit.MILLISECONDS))
+        IO.sleep(FiniteDuration(500, TimeUnit.MILLISECONDS))
       }
     } yield ExitCode.Success
   }


### PR DESCRIPTION
This PR upgrades the Cats-Effect library to the newest version. Unfortunately, Cats-Effect 3 is not backward compatible with Cats-Effect 2. So users that use old Cats-Effect will not be able to use this library (in case they use scala-effect-api) in the newest version without migration to Cats-Effect 3.